### PR TITLE
fix: fix "GitHub" capitalization across project

### DIFF
--- a/_posts/035. sqla migrated to git.rst
+++ b/_posts/035. sqla migrated to git.rst
@@ -8,7 +8,7 @@ The SQLAlchemy source repository has been migrated to Git.
 
 There are now twin repository mirrors for SQLAlchemy hosted
 at `Bitbucket <https://bitbucket.org/zzzeek/sqlalchemy>`_
-and `Github <https://github.com/zzzeek/sqlalchemy>`_.
+and `GitHub <https://github.com/zzzeek/sqlalchemy>`_.
 
 Rationale for the migration includes the following:
 
@@ -34,7 +34,7 @@ Rationale for the migration includes the following:
   for the purposes of collapsing changesets or manipulating branches
   is a first class and widely used feature in Git.
 
-* Largely due to the popularity of Github, Git has achieved a much
+* Largely due to the popularity of GitHub, Git has achieved a much
   higher userbase, to the degree where we regularly have users
   requesting us to move to Git so they can provide pull requests
   (as they don't want to learn Mercurial).
@@ -42,13 +42,13 @@ Rationale for the migration includes the following:
 SQLAlchemy's issue repository will remain hosted on Trac; while a
 Git repository can be mirrored in any number of places, an issue
 repository cannot (for now!  Can someone please create a distributed issue
-tracker?  Should be pretty doable, though getting Github/Bitbucket
+tracker?  Should be pretty doable, though getting GitHub/Bitbucket
 to use it, not so much...), so SQLAlchemy's long history of
 issue discussion remains maintained directly by the project.
 
 While we are favoring Bitbucket as the location of the "primary"
 push repository, users who wish to contribute should feel free
-to provide pull requests from either Bitbucket or Github; we should
+to provide pull requests from either Bitbucket or GitHub; we should
 be able to accommodate both.
 
 The SQLAlchemy Mercurial repository at http://hg.sqlalchemy.org/ will

--- a/_posts/043. trac moved to bitbucket.rst
+++ b/_posts/043. trac moved to bitbucket.rst
@@ -10,10 +10,10 @@ for all issue tracking and wiki pages.
 SQLAlchemy began using Bitbucket some years ago for pull requests, and
 then when the move to Git was made, Bitbucket became the originating point
 for the git main, which remains mirrored on SQLAlchemy's host as well as
-on Github.  However, the issue system has for SQLAlchemy's entire life remained
+on GitHub.  However, the issue system has for SQLAlchemy's entire life remained
 hosted on Trac.
 
-A move from Trac to another system like Github or Bitbucket was not feasable
+A move from Trac to another system like GitHub or Bitbucket was not feasable
 until Bitbucket added an advanced import/export feature which could maintain
 the full history, timestamps, and user accounts of the imported issues.
 When this feature was introduced, the SQLAlchemy project still was reluctant

--- a/_posts/146. sqla 1314 released.rst
+++ b/_posts/146. sqla 1314 released.rst
@@ -12,7 +12,7 @@ under Python 3 all exceptions that are "chained" to another internal exception
 should have a "cause" linked, to avoid misleading stack traces.   The new
 feature has been tested that it does not create new reference cycles as is a
 common issue with Python 3 exception objects, however users should report
-any regressions encountered on the Github issue tracker.
+any regressions encountered on the GitHub issue tracker.
 
 See the changelog for descriptions of all bug fixes.
 

--- a/_templates/header.mako
+++ b/_templates/header.mako
@@ -68,7 +68,7 @@
                         <li><a class="dropdown-item" href="${site_base}/participate.html">Participate</a></li>
                         <li><a class="dropdown-item" href="${site_base}/develop.html">Develop</a></li>
                         <li><a class="dropdown-item" href="${site_base}/codeofconduct.html">Code of Conduct</a></li>
-                        <li><a class="dropdown-item" href="${bb_base}">Github</a></li>
+                        <li><a class="dropdown-item" href="${bb_base}">GitHub</a></li>
                     </ul>
                 </li>
                 <li class="nav-item dropdown">

--- a/develop.html.mako
+++ b/develop.html.mako
@@ -33,9 +33,9 @@ these channels respect the <a href="/codeofconduct.html">Code of Conduct</a> whe
 seeking or providing support.</em></p>
 
 <ul>
-    <li>Github Discussions</li>
+    <li>GitHub Discussions</li>
     <ul>
-        <li>The <a href="/support.html#discussions">Github Discussions</a> forum is the most
+        <li>The <a href="/support.html#discussions">GitHub Discussions</a> forum is the most
             common - core devs assist users with issues of all kinds. All SQLAlchemy
             users and third-party library authors are encouraged to seek
             support here.

--- a/participate.html.mako
+++ b/participate.html.mako
@@ -37,7 +37,7 @@ Participate - SQLAlchemy
 
 <a name="github"></a>
 <h2>GitHub</h2>
-<p>SQLAlchemy uses <a href="https://github.com">Github</a> for bug reporting
+<p>SQLAlchemy uses <a href="https://github.com">GitHub</a> for bug reporting
 and issue tracking, Discussions, Wiki pages, and public source code access.
 </p>
 
@@ -47,7 +47,7 @@ and issue tracking, Discussions, Wiki pages, and public source code access.
 <p>Bugs are reported using GitHub.</p>
 
 <p>We greatly prefer that usage problems are reported as
-<a href="https://github.com/sqlalchemy/sqlalchemy/discussions">Github Discussions</a>
+<a href="https://github.com/sqlalchemy/sqlalchemy/discussions">GitHub Discussions</a>
 first, and not as issues.
 As issues are identified from the description of the problem, SQLAlchemy developers
 will open issues to be fixed as needed.
@@ -109,7 +109,7 @@ emailing us first</strong>, so that proper disclosure steps may be taken.
 <p>SQLAlchemy places great emphasis on polite, thoughtful, and constructive communication between users and developers.
     Rudeness, personal insults, or brusque answers are never appropriate, even for users with unreasonable requests.   See our <a href="codeofconduct.html">Code of Conduct</a> for a full statement.
     We also try to ensure that
-    no message on Github Discussions goes unanswered, even if the answer is simply to politely direct the user towards
+    no message on GitHub Discussions goes unanswered, even if the answer is simply to politely direct the user towards
     the appropriate section of documentation.   The core SQLAlchemy developers would like to encourage all users to help
     with this task - if you see a very basic question sitting on the list for a few days, that's us hoping you'll respond
     to it !  You have our permission :).</p>

--- a/support.html.mako
+++ b/support.html.mako
@@ -10,7 +10,7 @@ Support - SQLAlchemy
 
 <ul>
     <li><a href="#before">Before Requesting Support</a></li>
-    <li><a href="#discussions">Github Discussions</a></li>
+    <li><a href="#discussions">GitHub Discussions</a></li>
     <li><a href="#real-time">Real-time Channel</a></li>
     <li><a href="#professional">Professional Support with Tidelift</a></li>
 </ul>
@@ -26,16 +26,16 @@ constantly, sometimes dramatically so. Issues with the documentation may be
 reported as bugs (see <a href="/participate.html#bugs">reporting bugs</a>).
 Another approach is to search through the
 <a
-href="https://github.com/sqlalchemy/sqlalchemy/discussions">Github
+href="https://github.com/sqlalchemy/sqlalchemy/discussions">GitHub
 Discussions</a> forum which is fast becoming a primary informational resource.
 </p>
 
 <a name="discussions"></a>
-<h2>Github Discussions</h2>
+<h2>GitHub Discussions</h2>
 
 <p>SQLAlchemy and its related projects now offer support via the <a
-href="https://github.com/sqlalchemy/sqlalchemy/discussions">Github
-Discussions</a> link on the Github page for each project. This forum-style
+href="https://github.com/sqlalchemy/sqlalchemy/discussions">GitHub
+Discussions</a> link on the GitHub page for each project. This forum-style
 interface allows for discussions more or like that of a mailing list, but
 with better support for illustrating code samples and linking to issues.
 
@@ -84,7 +84,7 @@ single them out for individual assistance!  There are usually about 80-100
 members on at any given time - many of which can likely help with your issue.
 If your issue is genuinely more intricate and requiring of more skillful help
 than is currently available on IRC or Gitter, that's when it's time to post
-on the <a href="#discussions">Github Discussions forum</a>.</p>
+on the <a href="#discussions">GitHub Discussions forum</a>.</p>
 
 <a name="gitter"></a>
 <h3>Gitter Room</h3>


### PR DESCRIPTION
Hi, this PR simply updates all instances of 'Github' to 'GitHub' for consistent spelling. This aligns the content with the official capitalization of the GitHub name.